### PR TITLE
Fix package for 1.19.0

### DIFF
--- a/recipe/dummy_test.py
+++ b/recipe/dummy_test.py
@@ -1,0 +1,5 @@
+import pytest
+
+@pytest.mark.parametrize('i', range(5))
+def test(i):
+    pass

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,10 @@ requirements:
 test:
   imports:
     - xdist
+  files:
+    - dummy_test.py
+  commands:
+    - pytest -n2 dummy_test.py
 
 about:
   home: https://github.com/pytest-dev/pytest-xdist

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   {{ hash_type }}: {{ hash }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -30,6 +30,7 @@ requirements:
     - py >=1.4.22
     - pytest >=3.0.0
     - setuptools
+    - pytest-forked
 
 test:
   imports:


### PR DESCRIPTION
The current package for `1.19.0` is broken because now
pytest-xdist depends on `pytest-forked`.

Waiting until `pytest-forked` is added to conda-forge so we can
update the recipe and release a new `1.19.0` package, build number 1.